### PR TITLE
Add HEVC to supported android TV video codecs

### DIFF
--- a/lib/browsers/androidTV.js
+++ b/lib/browsers/androidTV.js
@@ -2,7 +2,7 @@ const Browser = require('./browser');
 
 class AndroidTV extends Browser {
     constructor(version) {
-        let supportedVideoCodecs = ["h263", "h264", "avc", "mpeg", "mpeg-4", "mpeg-4 sp"];
+        let supportedVideoCodecs = ["h263", "h264", "avc", "mpeg", "mpeg-4", "mpeg-4 sp", "hevc"];
         let supportedAudioCodecs = ["aac", "amr", "mp3", "midi", "pcm", "wave", "vorbis"];
 
         // Video codecs


### PR DESCRIPTION
Not adding DTS to supported audio, since it's not supported.

Closes #28 